### PR TITLE
allow for system-wide "make install"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,11 +75,19 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 ######################################################
 # COMPILING SAMPLE EXAMPLE
 ######################################################
-add_executable(example src/main.cpp ${BTSrcLibrary} ${BTHeadLibrary})
-target_link_libraries(example  ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${Boost_LIBRARIES})
+add_executable(btpp_example src/main.cpp ${BTSrcLibrary} ${BTHeadLibrary})
+target_link_libraries(btpp_example  ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${Boost_LIBRARIES})
 
 ######################################################
 # COMPILING LIBRARY
 ######################################################
 add_library(btpp SHARED ${BTSrcLibrary} ${BTHeadLibrary})
 target_link_libraries(btpp ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${Boost_LIBRARIES})
+
+######################################################
+# INSTALLATION OF LIBRARY AND EXECUTABLE TO /usr/local
+######################################################
+install (TARGETS btpp_example DESTINATION bin)
+install (TARGETS btpp DESTINATION lib)
+#install (FILES "${PROJECT_BINARY_DIR???}/???.h"
+#         DESTINATION include)


### PR DESCRIPTION
changed "sample/example" to "sample/btpp_example"; a "sudo make install" command (after "cmake ..") should install to /usr/local on an Ubuntu 14.04 system (/usr/local/bin/btpp_example and /usr/local/lib/libbtpp.so); see: https://cmake.org/cmake-tutorial/ and https://cmake.org/cmake/help/v3.0/command/install.html
