### PR TITLE
Transition to IDLE changed and Unit Test extended

### DIFF
--- a/gtest/gtest_tree.cpp
+++ b/gtest/gtest_tree.cpp
@@ -15,321 +15,313 @@
 #include "condition_test_node.h"
 #include "behavior_tree_core/behavior_tree.h"
 
+using BT::NodeStatus;
+
 struct SimpleSequenceTest : testing::Test
 {
-    std::unique_ptr<BT::SequenceNode> root;
-    std::unique_ptr<BT::ActionTestNode> action;
-    std::unique_ptr<BT::ConditionTestNode> condition;
-    SimpleSequenceTest()
+    BT::SequenceNode root;
+    BT::ActionTestNode action;
+    BT::ConditionTestNode condition;
+
+    SimpleSequenceTest():
+        root("root_sequence"),
+        action("action"),
+        condition("condition")
     {
-        action.reset(new BT::ActionTestNode("action"));
-        condition.reset(  new BT::ConditionTestNode("condition") );
-
-        root.reset(  new BT::SequenceNode("seq1") );
-
-        root->addChild(condition.get());
-        root->addChild(action.get());
+        root.addChild(&condition);
+        root.addChild(&action);
     }
 };
 
 struct ComplexSequenceTest : testing::Test
 {
-    std::unique_ptr<BT::SequenceNode> root;
-    std::unique_ptr<BT::ActionTestNode> action_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_2;
+    BT::SequenceNode root;
+    BT::ActionTestNode action_1;
+    BT::ConditionTestNode condition_1;
+    BT::ConditionTestNode condition_2;
 
-    std::unique_ptr<BT::SequenceNode> seq_conditions;
+    BT::SequenceNode seq_conditions;
 
-    ComplexSequenceTest()
+    ComplexSequenceTest():
+        root("root_sequence"),
+        action_1("action_1"),
+        condition_1("condition_1"),
+        condition_2("condition_2"),
+        seq_conditions("sequence_conditions")
     {
-        action_1.reset(  new BT::ActionTestNode("action 1") );
-
-        condition_1.reset(  new BT::ConditionTestNode("condition 1" ));
-        condition_2.reset(  new BT::ConditionTestNode("condition 2" ));
-        seq_conditions.reset(  new BT::SequenceNode("sequence_conditions") );
-
-        seq_conditions->addChild(condition_1.get());
-        seq_conditions->addChild(condition_2.get());
-
-        root.reset(  new BT::SequenceNode("root") );
-        root->addChild(seq_conditions.get());
-        root->addChild(action_1.get());
+        root.addChild(&seq_conditions);
+        {
+            seq_conditions.addChild(&condition_1);
+            seq_conditions.addChild(&condition_2);
+        }
+        root.addChild(&action_1);
     }
 };
 
 struct ComplexSequence2ActionsTest : testing::Test
 {
-    std::unique_ptr<BT::SequenceNode> root;
-    std::unique_ptr<BT::ActionTestNode> action_1;
-    std::unique_ptr<BT::ActionTestNode> action_2;
+    BT::SequenceNode root;
+    BT::ActionTestNode action_1;
+    BT::ActionTestNode action_2;
+    BT::SequenceNode seq_1;
+    BT::SequenceNode seq_2;
 
-    std::unique_ptr<BT::ConditionTestNode> condition_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_2;
+    BT::ConditionTestNode condition_1;
+    BT::ConditionTestNode condition_2;
 
-    std::unique_ptr<BT::SequenceNode> seq_1;
-    std::unique_ptr<BT::SequenceNode> seq_2;
-
-    ComplexSequence2ActionsTest()
+    ComplexSequence2ActionsTest():
+        root("root_sequence"),
+        action_1("action_1"),
+        action_2("action_2"),
+        seq_1("sequence_1"),
+        seq_2("sequence_2"),
+        condition_1("condition_1"),
+        condition_2("condition_2")
     {
-        action_1.reset(  new BT::ActionTestNode("action 1") );
-        action_2.reset(  new BT::ActionTestNode("action 2") );
-        seq_1.reset(  new BT::SequenceNode("sequence_1") );
-        seq_2.reset(  new BT::SequenceNode("sequence_c2") );
-
-        condition_1.reset(  new BT::ConditionTestNode("condition 1") );
-        condition_2.reset(  new BT::ConditionTestNode("condition 2") );
-
-        seq_1->addChild(condition_1.get());
-        seq_1->addChild(action_1.get());
-
-        seq_2->addChild(condition_2.get());
-        seq_2->addChild(action_2.get());
-
-        root.reset(  new BT::SequenceNode("root") );
-        root->addChild(seq_1.get());
-        root->addChild(seq_2.get());
+        root.addChild(&seq_1);
+        {
+            seq_1.addChild(&condition_1);
+            seq_1.addChild(&action_1);
+        }
+        root.addChild(&seq_2);
+        {
+            seq_2.addChild(&condition_2);
+            seq_2.addChild(&action_2);
+        }
     }
 };
 
 struct SimpleFallbackTest : testing::Test
 {
-    std::unique_ptr<BT::FallbackNode> root;
-    std::unique_ptr<BT::ActionTestNode> action;
-    std::unique_ptr<BT::ConditionTestNode> condition;
-    SimpleFallbackTest()
+    BT::FallbackNode root;
+    BT::ActionTestNode action;
+    BT::ConditionTestNode condition;
+
+    SimpleFallbackTest():
+        root("root_fallback"),
+        action("action"),
+        condition("condition")
     {
-        action.reset(  new BT::ActionTestNode("action") );
-        condition.reset(  new BT::ConditionTestNode("condition") );
-
-        root.reset(  new BT::FallbackNode("seq1") );
-
-        root->addChild(condition.get());
-        root->addChild(action.get());
+        root.addChild(&condition);
+        root.addChild(&action);
     }
 };
 
 struct ComplexFallbackTest : testing::Test
 {
-    std::unique_ptr<BT::FallbackNode> root;
-    std::unique_ptr<BT::ActionTestNode> action_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_2;
+    BT::FallbackNode root;
+    BT::ActionTestNode action_1;
+    BT::ConditionTestNode condition_1;
+    BT::ConditionTestNode condition_2;
 
-    std::unique_ptr<BT::FallbackNode> sel_conditions;
+    BT::FallbackNode sel_conditions;
 
-    ComplexFallbackTest()
+    ComplexFallbackTest():
+        root("root_fallback"),
+        action_1("action_1"),
+        condition_1("condition_1"),
+        condition_2("condition_2"),
+        sel_conditions("fallback_conditions")
     {
-        action_1.reset(  new BT::ActionTestNode("action 1") );
-        condition_1.reset(  new BT::ConditionTestNode("condition 1") );
-        condition_2.reset(  new BT::ConditionTestNode("condition 2") );
-        sel_conditions.reset(  new BT::FallbackNode("fallback_conditions") );
-
-        sel_conditions->addChild(condition_1.get());
-        sel_conditions->addChild(condition_2.get());
-
-        root.reset(  new BT::FallbackNode("root") );
-        root->addChild(sel_conditions.get());
-        root->addChild(action_1.get());
+        root.addChild(&sel_conditions);
+        {
+            sel_conditions.addChild(&condition_1);
+            sel_conditions.addChild(&condition_2);
+        }
+        root.addChild(&action_1);
     }
 };
 
 struct BehaviorTreeTest : testing::Test
 {
-    std::unique_ptr<BT::SequenceNode> root;
-    std::unique_ptr<BT::ActionTestNode> action_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_2;
+    BT::SequenceNode root;
+    BT::ActionTestNode action_1;
+    BT::ConditionTestNode condition_1;
+    BT::ConditionTestNode condition_2;
 
-    std::unique_ptr<BT::FallbackNode> sel_conditions;
+    BT::FallbackNode sel_conditions;
 
-    BehaviorTreeTest()
+    BehaviorTreeTest():
+        root("root_sequence"),
+        action_1("action_1"),
+        condition_1("condition_1"),
+        condition_2("condition_2"),
+        sel_conditions("fallback_conditions")
     {
-        action_1.reset(  new BT::ActionTestNode("action 1") );
-        condition_1.reset(  new BT::ConditionTestNode("condition 1") );
-        condition_2.reset(  new BT::ConditionTestNode("condition 2") );
-        sel_conditions.reset(  new BT::FallbackNode("fallback_conditions") );
 
-        sel_conditions->addChild(condition_1.get());
-        sel_conditions->addChild(condition_2.get());
-
-        root.reset(  new BT::SequenceNode("root") );
-        root->addChild(sel_conditions.get());
-        root->addChild(action_1.get());
+        root.addChild(&sel_conditions);
+        {
+            sel_conditions.addChild(&condition_1);
+            sel_conditions.addChild(&condition_2);
+        }
+        root.addChild(&action_1);
     }
 };
 
 struct SimpleSequenceWithMemoryTest : testing::Test
 {
-    std::unique_ptr<BT::SequenceNodeWithMemory> root;
-    std::unique_ptr<BT::ActionTestNode> action;
-    std::unique_ptr<BT::ConditionTestNode> condition;
-    SimpleSequenceWithMemoryTest()
+    BT::SequenceNodeWithMemory root;
+    BT::ActionTestNode action;
+    BT::ConditionTestNode condition;
+
+    SimpleSequenceWithMemoryTest():
+        root("root_sequence"),
+        action("action"),
+        condition("condition")
     {
-        action.reset(  new BT::ActionTestNode("action") );
-        condition.reset(  new BT::ConditionTestNode("condition") );
-
-        root.reset(  new BT::SequenceNodeWithMemory("seq1") );
-
-        root->addChild(condition.get());
-        root->addChild(action.get());
+        root.addChild(&condition);
+        root.addChild(&action);
     }
 };
 
 struct ComplexSequenceWithMemoryTest : testing::Test
 {
-    std::unique_ptr<BT::SequenceNodeWithMemory> root;
+    BT::SequenceNodeWithMemory root;
 
-    std::unique_ptr<BT::ActionTestNode> action_1;
-    std::unique_ptr<BT::ActionTestNode> action_2;
+    BT::ActionTestNode action_1;
+    BT::ActionTestNode action_2;
 
-    std::unique_ptr<BT::ConditionTestNode> condition_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_2;
+    BT::ConditionTestNode condition_1;
+    BT::ConditionTestNode condition_2;
 
-    std::unique_ptr<BT::SequenceNodeWithMemory> seq_conditions;
-    std::unique_ptr<BT::SequenceNodeWithMemory> seq_actions;
+    BT::SequenceNodeWithMemory seq_conditions;
+    BT::SequenceNodeWithMemory seq_actions;
 
-    ComplexSequenceWithMemoryTest()
+    ComplexSequenceWithMemoryTest():
+        root("root_sequence"),
+        action_1("action_1"),
+        action_2("action_2"),
+        condition_1("condition_1"),
+        condition_2("condition_2"),
+        seq_conditions("sequence_conditions"),
+        seq_actions("sequence_actions")
     {
-        action_1.reset(  new BT::ActionTestNode("action 1") );
-        action_2.reset(  new BT::ActionTestNode("action 2") );
 
-        condition_1.reset(  new BT::ConditionTestNode("condition 1") );
-        condition_2.reset(  new BT::ConditionTestNode("condition 2") );
-
-        seq_conditions.reset(  new BT::SequenceNodeWithMemory("sequence_conditions") );
-        seq_actions.reset(  new BT::SequenceNodeWithMemory("sequence_actions") );
-
-        seq_actions->addChild(action_1.get());
-        seq_actions->addChild(action_2.get());
-
-        seq_conditions->addChild(condition_1.get());
-        seq_conditions->addChild(condition_2.get());
-
-        root.reset(  new BT::SequenceNodeWithMemory("root") );
-        root->addChild(seq_conditions.get());
-        root->addChild(seq_actions.get());
+        root.addChild(&seq_conditions);
+        {
+            seq_conditions.addChild(&condition_1);
+            seq_conditions.addChild(&condition_2);
+        }
+        root.addChild(&seq_actions);
+        {
+            seq_actions.addChild(&action_1);
+            seq_actions.addChild(&action_2);
+        }
     }
 };
 
 struct SimpleFallbackWithMemoryTest : testing::Test
 {
-    std::unique_ptr<BT::FallbackNodeWithMemory> root;
-    std::unique_ptr<BT::ActionTestNode> action;
-    std::unique_ptr<BT::ConditionTestNode> condition;
-    SimpleFallbackWithMemoryTest()
+    BT::FallbackNodeWithMemory root;
+    BT::ActionTestNode action;
+    BT::ConditionTestNode condition;
+
+    SimpleFallbackWithMemoryTest():
+        root("root_sequence"),
+        action("action"),
+        condition("condition")
     {
-        action.reset(  new BT::ActionTestNode("action") );
-        condition.reset(  new BT::ConditionTestNode("condition") );
-
-        root.reset(  new BT::FallbackNodeWithMemory("seq1") );
-
-        root->addChild(condition.get());
-        root->addChild(action.get());
+        root.addChild(&condition);
+        root.addChild(&action);
     }
 };
 
 struct ComplexFallbackWithMemoryTest : testing::Test
 {
-    std::unique_ptr<BT::FallbackNodeWithMemory> root;
+    BT::FallbackNodeWithMemory root;
 
-    std::unique_ptr<BT::ActionTestNode> action_1;
-    std::unique_ptr<BT::ActionTestNode> action_2;
+    BT::ActionTestNode action_1;
+    BT::ActionTestNode action_2;
 
-    std::unique_ptr<BT::ConditionTestNode> condition_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_2;
+    BT::ConditionTestNode condition_1;
+    BT::ConditionTestNode condition_2;
 
-    std::unique_ptr<BT::FallbackNodeWithMemory> fal_conditions;
-    std::unique_ptr<BT::FallbackNodeWithMemory> fal_actions;
+    BT::FallbackNodeWithMemory fal_conditions;
+    BT::FallbackNodeWithMemory fal_actions;
 
-    ComplexFallbackWithMemoryTest()
+    ComplexFallbackWithMemoryTest():
+        root("root_fallback"),
+        action_1("action_1"),
+        action_2("action_2"),
+        condition_1("condition_1"),
+        condition_2("condition_2"),
+        fal_conditions("fallback_conditions"),
+        fal_actions("fallback_actions")
     {
-        action_1.reset(  new BT::ActionTestNode("action 1") );
-        action_2.reset(  new BT::ActionTestNode("action 2") );
-        condition_1.reset(  new BT::ConditionTestNode("condition 1") );
-        condition_2.reset(  new BT::ConditionTestNode("condition 2") );
-
-        fal_conditions.reset(  new BT::FallbackNodeWithMemory("fallback_conditions") );
-        fal_actions.reset(  new BT::FallbackNodeWithMemory("fallback_actions") );
-
-        fal_actions->addChild(action_1.get());
-        fal_actions->addChild(action_2.get());
-
-        fal_conditions->addChild(condition_1.get());
-        fal_conditions->addChild(condition_2.get());
-
-        root.reset(  new BT::FallbackNodeWithMemory("root") );
-        root->addChild(fal_conditions.get());
-        root->addChild(fal_actions.get());
+        root.addChild(&fal_conditions);
+        {
+            fal_conditions.addChild(&condition_1);
+            fal_conditions.addChild(&condition_2);
+        }
+        root.addChild(&fal_actions);
+        {
+            fal_actions.addChild(&action_1);
+            fal_actions.addChild(&action_2);
+        }
     }
 };
 
 struct SimpleParallelTest : testing::Test
 {
-    std::unique_ptr<BT::ParallelNode> root;
-    std::unique_ptr<BT::ActionTestNode> action_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_1;
+    BT::ParallelNode root;
+    BT::ActionTestNode action_1;
+    BT::ConditionTestNode condition_1;
 
-    std::unique_ptr<BT::ActionTestNode> action_2;
-    std::unique_ptr<BT::ConditionTestNode> condition_2;
+    BT::ActionTestNode action_2;
+    BT::ConditionTestNode condition_2;
 
-    SimpleParallelTest()
+    SimpleParallelTest():
+        root("root_parallel",4),
+        action_1("action_1"),
+        condition_1("condition_1"),
+        action_2("action_2"),
+        condition_2("condition_2")
     {
-        action_1.reset(  new BT::ActionTestNode("action 1") );
-        condition_1.reset(  new BT::ConditionTestNode("condition 1") );
-
-        action_2.reset(  new BT::ActionTestNode("action 2") );
-        condition_2.reset(  new BT::ConditionTestNode("condition 2") );
-
-        root.reset(  new BT::ParallelNode("par", 4) );
-
-        root->addChild(condition_1.get());
-        root->addChild(action_1.get());
-        root->addChild(condition_2.get());
-        root->addChild(action_2.get());
+        root.addChild(&condition_1);
+        root.addChild(&action_1);
+        root.addChild(&condition_2);
+        root.addChild(&action_2);
     }
 };
 
 struct ComplexParallelTest : testing::Test
 {
-    std::unique_ptr<BT::ParallelNode> root;
-    std::unique_ptr<BT::ParallelNode> parallel_1;
-    std::unique_ptr<BT::ParallelNode> parallel_2;
+    BT::ParallelNode root;
+    BT::ParallelNode parallel_1;
+    BT::ParallelNode parallel_2;
 
-    std::unique_ptr<BT::ActionTestNode> action_1;
-    std::unique_ptr<BT::ConditionTestNode> condition_1;
+    BT::ActionTestNode action_1;
+    BT::ConditionTestNode condition_1;
 
-    std::unique_ptr<BT::ActionTestNode> action_2;
-    std::unique_ptr<BT::ConditionTestNode> condition_2;
+    BT::ActionTestNode action_2;
+    BT::ConditionTestNode condition_2;
 
-    std::unique_ptr<BT::ActionTestNode> action_3;
-    std::unique_ptr<BT::ConditionTestNode> condition_3;
+    BT::ActionTestNode action_3;
+    BT::ConditionTestNode condition_3;
 
-    ComplexParallelTest()
+    ComplexParallelTest():
+        root("root",2),
+        parallel_1("par1",3),
+        parallel_2("par2",1),
+        action_1("action_1"),
+        condition_1("condition_1"),
+        action_2("action_2"),
+        condition_2("condition_2"),
+        action_3("action_3"),
+        condition_3("condition_3")
     {
-        action_1.reset(  new BT::ActionTestNode("action 1") );
-        condition_1.reset(  new BT::ConditionTestNode("condition 1") );
-
-        action_2.reset(  new BT::ActionTestNode("action 2") );
-        condition_2.reset(  new BT::ConditionTestNode("condition 2") );
-
-        action_3.reset(  new BT::ActionTestNode("action 3") );
-        condition_3.reset(  new BT::ConditionTestNode("condition 3") );
-
-        root.reset(  new BT::ParallelNode("root", 2) );
-        parallel_1.reset(  new BT::ParallelNode("par1", 3) );
-        parallel_2.reset(  new BT::ParallelNode("par2", 1) );
-
-        parallel_1->addChild(condition_1.get());
-        parallel_1->addChild(action_1.get());
-        parallel_1->addChild(condition_2.get());
-        parallel_1->addChild(action_2.get());
-
-        parallel_2->addChild(condition_3.get());
-        parallel_2->addChild(action_3.get());
-
-        root->addChild(parallel_1.get());
-        root->addChild(parallel_2.get());
+        root.addChild(&parallel_1);
+        {
+            parallel_1.addChild(&condition_1);
+            parallel_1.addChild(&action_1);
+            parallel_1.addChild(&condition_2);
+            parallel_1.addChild(&action_2);
+        }
+        root.addChild(&parallel_2);
+        {
+            parallel_2.addChild(&condition_3);
+            parallel_2.addChild(&action_3);
+        }
     }
 };
 
@@ -339,477 +331,477 @@ TEST_F(SimpleSequenceTest, ConditionTrue)
 {
     std::cout << "Ticking the root node !" << std::endl << std::endl;
     // Ticking the root node
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, action->status());
-    ASSERT_EQ(BT::RUNNING, state);
-    root->halt();
+    ASSERT_EQ(NodeStatus::RUNNING, action.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
+    root.halt();
 }
 
 TEST_F(SimpleSequenceTest, ConditionTurnToFalse)
 {
-    BT::NodeStatus state = root->executeTick();
-    condition->set_boolean_value(false);
+    BT::NodeStatus state = root.executeTick();
+    condition.set_boolean_value(false);
 
-    state = root->executeTick();
-    ASSERT_EQ(BT::FAILURE, state);
-    ASSERT_EQ(BT::HALTED, action->status());
-    root->halt();
+    state = root.executeTick();
+    ASSERT_EQ(NodeStatus::FAILURE, state);
+    ASSERT_EQ(NodeStatus::HALTED, action.status());
+    root.halt();
 }
 
 TEST_F(ComplexSequenceTest, ComplexSequenceConditionsTrue)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::RUNNING, state);
-    root->halt();
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
+    root.halt();
 }
 
 TEST_F(ComplexSequence2ActionsTest, ConditionsTrue)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    state = root->executeTick();
+    state = root.executeTick();
 
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    state = root->executeTick();
-    state = root->executeTick();
+    state = root.executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, state);
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::RUNNING, seq_1->status());
-    ASSERT_EQ(BT::HALTED, seq_2->status());
-    ASSERT_EQ(BT::HALTED, action_2->status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::RUNNING, seq_1.status());
+    ASSERT_EQ(NodeStatus::HALTED, seq_2.status());
+    ASSERT_EQ(NodeStatus::HALTED, action_2.status());
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexSequenceTest, ComplexSequenceConditions1ToFalse)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    condition_1->set_boolean_value(false);
+    condition_1.set_boolean_value(false);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::FAILURE, state);
-    ASSERT_EQ(BT::HALTED, action_1->status());
-    root->halt();
+    ASSERT_EQ(NodeStatus::FAILURE, state);
+    ASSERT_EQ(NodeStatus::HALTED, action_1.status());
+    root.halt();
 }
 
 TEST_F(ComplexSequenceTest, ComplexSequenceConditions2ToFalse)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    condition_2->set_boolean_value(false);
+    condition_2.set_boolean_value(false);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::FAILURE, state);
-    ASSERT_EQ(BT::HALTED, action_1->status());
-    root->halt();
+    ASSERT_EQ(NodeStatus::FAILURE, state);
+    ASSERT_EQ(NodeStatus::HALTED, action_1.status());
+    root.halt();
 }
 
 TEST_F(SimpleFallbackTest, ConditionTrue)
 {
     std::cout << "Ticking the root node !" << std::endl << std::endl;
     // Ticking the root node
-    condition->set_boolean_value(true);
-    BT::NodeStatus state = root->executeTick();
+    condition.set_boolean_value(true);
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, action->status());
-    ASSERT_EQ(BT::SUCCESS, state);
-    root->halt();
+    ASSERT_EQ(NodeStatus::IDLE, action.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, state);
+    root.halt();
 }
 
 TEST_F(SimpleFallbackTest, ConditionToFalse)
 {
-    condition->set_boolean_value(false);
+    condition.set_boolean_value(false);
 
-    BT::NodeStatus state = root->executeTick();
-    condition->set_boolean_value(true);
+    BT::NodeStatus state = root.executeTick();
+    condition.set_boolean_value(true);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::SUCCESS, state);
-    ASSERT_EQ(BT::HALTED, action->status());
-    root->halt();
+    ASSERT_EQ(NodeStatus::SUCCESS, state);
+    ASSERT_EQ(NodeStatus::HALTED, action.status());
+    root.halt();
 }
 
 TEST_F(ComplexFallbackTest, Condition1ToTrue)
 {
-    condition_1->set_boolean_value(false);
-    condition_2->set_boolean_value(false);
+    condition_1.set_boolean_value(false);
+    condition_2.set_boolean_value(false);
 
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    condition_1->set_boolean_value(true);
+    condition_1.set_boolean_value(true);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::SUCCESS, state);
+    ASSERT_EQ(NodeStatus::SUCCESS, state);
 
-    ASSERT_EQ(BT::HALTED, action_1->status());
-    root->halt();
+    ASSERT_EQ(NodeStatus::HALTED, action_1.status());
+    root.halt();
 }
 
 TEST_F(ComplexFallbackTest, Condition2ToTrue)
 {
-    condition_1->set_boolean_value(false);
-    condition_2->set_boolean_value(false);
+    condition_1.set_boolean_value(false);
+    condition_2.set_boolean_value(false);
 
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    condition_2->set_boolean_value(true);
+    condition_2.set_boolean_value(true);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::SUCCESS, state);
-    ASSERT_EQ(BT::HALTED, action_1->status());
-    root->halt();
+    ASSERT_EQ(NodeStatus::SUCCESS, state);
+    ASSERT_EQ(NodeStatus::HALTED, action_1.status());
+    root.halt();
 }
 
 TEST_F(BehaviorTreeTest, Condition1ToFalseCondition2True)
 {
-    condition_1->set_boolean_value(false);
-    condition_2->set_boolean_value(true);
+    condition_1.set_boolean_value(false);
+    condition_2.set_boolean_value(true);
 
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, state);
-    ASSERT_EQ(BT::RUNNING, action_1->status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(BehaviorTreeTest, Condition2ToFalseCondition1True)
 {
-    condition_2->set_boolean_value(false);
-    condition_1->set_boolean_value(true);
+    condition_2.set_boolean_value(false);
+    condition_1.set_boolean_value(true);
 
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, state);
-    ASSERT_EQ(BT::RUNNING, action_1->status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(SimpleSequenceWithMemoryTest, ConditionTrue)
 {
     std::cout << "Ticking the root node !" << std::endl << std::endl;
     // Ticking the root node
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    ASSERT_EQ(BT::RUNNING, action->status());
-    ASSERT_EQ(BT::RUNNING, state);
-    root->halt();
+    ASSERT_EQ(NodeStatus::RUNNING, action.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
+    root.halt();
 }
 
 TEST_F(SimpleSequenceWithMemoryTest, ConditionTurnToFalse)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    condition->set_boolean_value(false);
+    condition.set_boolean_value(false);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, state);
-    ASSERT_EQ(BT::RUNNING, action->status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action.status());
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexSequenceWithMemoryTest, ConditionsTrue)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::IDLE, action_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexSequenceWithMemoryTest, Conditions1ToFalse)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    condition_1->set_boolean_value(false);
+    condition_1.set_boolean_value(false);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::IDLE, action_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
-    root->halt();
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
+    root.halt();
 }
 
 TEST_F(ComplexSequenceWithMemoryTest, Conditions2ToFalse)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    condition_2->set_boolean_value(false);
+    condition_2.set_boolean_value(false);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::IDLE, action_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexSequenceWithMemoryTest, Action1Done)
 {
-    root->executeTick();
+    root.executeTick();
 
-    condition_2->set_boolean_value(false);
+    condition_2.set_boolean_value(false);
 
-    root->executeTick();
+    root.executeTick();
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-    root->executeTick();
+    root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, action_2->status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_2.status());
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(SimpleFallbackWithMemoryTest, ConditionFalse)
 {
     std::cout << "Ticking the root node !" << std::endl << std::endl;
     // Ticking the root node
-    condition->set_boolean_value(false);
-    BT::NodeStatus state = root->executeTick();
+    condition.set_boolean_value(false);
+    BT::NodeStatus state = root.executeTick();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    ASSERT_EQ(BT::RUNNING, action->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(SimpleFallbackWithMemoryTest, ConditionTurnToTrue)
 {
-    condition->set_boolean_value(false);
+    condition.set_boolean_value(false);
 
-    BT::NodeStatus state = root->executeTick();
-    condition->set_boolean_value(true);
+    BT::NodeStatus state = root.executeTick();
+    condition.set_boolean_value(true);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, state);
-    ASSERT_EQ(BT::RUNNING, action->status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action.status());
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexFallbackWithMemoryTest, ConditionsTrue)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, action_1->status());
-    ASSERT_EQ(BT::IDLE, action_2->status());
-    ASSERT_EQ(BT::SUCCESS, state);
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexFallbackWithMemoryTest, Condition1False)
 {
-    condition_1->set_boolean_value(false);
-    BT::NodeStatus state = root->executeTick();
+    condition_1.set_boolean_value(false);
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, action_1->status());
-    ASSERT_EQ(BT::IDLE, action_2->status());
-    ASSERT_EQ(BT::SUCCESS, state);
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexFallbackWithMemoryTest, ConditionsFalse)
 {
-    condition_1->set_boolean_value(false);
-    condition_2->set_boolean_value(false);
-    BT::NodeStatus state = root->executeTick();
+    condition_1.set_boolean_value(false);
+    condition_2.set_boolean_value(false);
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::IDLE, action_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexFallbackWithMemoryTest, Conditions1ToTrue)
 {
-    condition_1->set_boolean_value(false);
-    condition_2->set_boolean_value(false);
-    BT::NodeStatus state = root->executeTick();
-    condition_1->set_boolean_value(true);
+    condition_1.set_boolean_value(false);
+    condition_2.set_boolean_value(false);
+    BT::NodeStatus state = root.executeTick();
+    condition_1.set_boolean_value(true);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::IDLE, action_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexFallbackWithMemoryTest, Conditions2ToTrue)
 {
-    condition_1->set_boolean_value(false);
+    condition_1.set_boolean_value(false);
 
-    condition_2->set_boolean_value(false);
+    condition_2.set_boolean_value(false);
 
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    condition_2->set_boolean_value(true);
+    condition_2.set_boolean_value(true);
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::IDLE, action_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexFallbackWithMemoryTest, Action1Failed)
 {
-    action_1->set_boolean_value(false);
-    condition_1->set_boolean_value(false);
-    condition_2->set_boolean_value(false);
+    action_1.set_boolean_value(false);
+    condition_1.set_boolean_value(false);
+    condition_2.set_boolean_value(false);
 
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    state = root->executeTick();
+    state = root.executeTick();
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, action_1->status());
-    ASSERT_EQ(BT::RUNNING, action_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(SimpleParallelTest, ConditionsTrue)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, condition_1->status());
-    ASSERT_EQ(BT::IDLE, condition_2->status());
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::RUNNING, action_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(SimpleParallelTest, Threshold_3)
 {
-    root->setThresholdM(3);
-    action_2->set_time(200);
-    root->executeTick();
+    root.setThresholdM(3);
+    action_2.set_time(200);
+    root.executeTick();
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, condition_1->status());
-    ASSERT_EQ(BT::IDLE, condition_2->status());
-    ASSERT_EQ(BT::IDLE, action_1->status());
-    ASSERT_EQ(BT::HALTED, action_2->status());
-    ASSERT_EQ(BT::SUCCESS, state);
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::HALTED, action_2.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(SimpleParallelTest, Threshold_1)
 {
-    root->setThresholdM(1);
-    BT::NodeStatus state = root->executeTick();
+    root.setThresholdM(1);
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, condition_1->status());
-    ASSERT_EQ(BT::IDLE, condition_2->status());
-    ASSERT_EQ(BT::IDLE, action_1->status());
-    ASSERT_EQ(BT::IDLE, action_2->status());
-    ASSERT_EQ(BT::SUCCESS, state);
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_2.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, state);
 
-    root->halt();
+    root.halt();
 }
 TEST_F(ComplexParallelTest, ConditionsTrue)
 {
-    BT::NodeStatus state = root->executeTick();
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, condition_1->status());
-    ASSERT_EQ(BT::IDLE, condition_2->status());
-    ASSERT_EQ(BT::IDLE, condition_3->status());
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::RUNNING, action_2->status());
-    ASSERT_EQ(BT::IDLE, action_3->status());
-    ASSERT_EQ(BT::RUNNING, parallel_1->status());
-    ASSERT_EQ(BT::IDLE, parallel_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_3.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_3.status());
+    ASSERT_EQ(NodeStatus::RUNNING, parallel_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, parallel_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexParallelTest, Condition3False)
 {
-    condition_3->set_boolean_value(false);
-    BT::NodeStatus state = root->executeTick();
+    condition_3.set_boolean_value(false);
+    BT::NodeStatus state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, condition_1->status());
-    ASSERT_EQ(BT::IDLE, condition_2->status());
-    ASSERT_EQ(BT::IDLE, condition_3->status());
-    ASSERT_EQ(BT::RUNNING, action_1->status());
-    ASSERT_EQ(BT::RUNNING, action_2->status());
-    ASSERT_EQ(BT::RUNNING, action_3->status());
-    ASSERT_EQ(BT::RUNNING, parallel_1->status());
-    ASSERT_EQ(BT::RUNNING, parallel_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_3.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_1.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_3.status());
+    ASSERT_EQ(NodeStatus::RUNNING, parallel_1.status());
+    ASSERT_EQ(NodeStatus::RUNNING, parallel_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    root->halt();
+    root.halt();
 }
 
 TEST_F(ComplexParallelTest, Condition3FalseAction1Done)
 {
-    action_2->set_time(10);
-    action_3->set_time(10);
+    action_2.set_time(10);
+    action_3.set_time(10);
 
-    condition_3->set_boolean_value(false);
-    BT::NodeStatus state = root->executeTick();
+    condition_3.set_boolean_value(false);
+    BT::NodeStatus state = root.executeTick();
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-    ASSERT_EQ(BT::IDLE, condition_1->status());
-    ASSERT_EQ(BT::IDLE, condition_2->status());
-    ASSERT_EQ(BT::IDLE, condition_3->status());
-    ASSERT_EQ(BT::SUCCESS, action_1->status());     // success not read yet by the node parallel_1
-    ASSERT_EQ(BT::RUNNING, parallel_1->status());   // parallel_1 hasn't realize (yet) that action_1 has succeeded
+    ASSERT_EQ(NodeStatus::IDLE, condition_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, condition_3.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, action_1.status());     // success not read yet by the node parallel_1
+    ASSERT_EQ(NodeStatus::RUNNING, parallel_1.status());   // parallel_1 hasn't realize (yet) that action_1 has succeeded
 
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, action_1->status());
-    ASSERT_EQ(BT::IDLE, parallel_1->status());
-    ASSERT_EQ(BT::HALTED, action_2->status());
-    ASSERT_EQ(BT::RUNNING, action_3->status());
-    ASSERT_EQ(BT::RUNNING, parallel_2->status());
-    ASSERT_EQ(BT::RUNNING, state);
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, parallel_1.status());
+    ASSERT_EQ(NodeStatus::HALTED, action_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, action_3.status());
+    ASSERT_EQ(NodeStatus::RUNNING, parallel_2.status());
+    ASSERT_EQ(NodeStatus::RUNNING, state);
 
-    state = root->executeTick();
+    state = root.executeTick();
     std::this_thread::sleep_for(std::chrono::milliseconds(1500));
-    state = root->executeTick();
+    state = root.executeTick();
 
-    ASSERT_EQ(BT::IDLE, parallel_2->status());
-    ASSERT_EQ(BT::IDLE, action_1->status());
-    ASSERT_EQ(BT::IDLE, parallel_1->status());
-    ASSERT_EQ(BT::IDLE, action_3->status());
-    ASSERT_EQ(BT::IDLE, parallel_2->status());
-    ASSERT_EQ(BT::SUCCESS, state);
+    ASSERT_EQ(NodeStatus::IDLE, parallel_2.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, parallel_1.status());
+    ASSERT_EQ(NodeStatus::IDLE, action_3.status());
+    ASSERT_EQ(NodeStatus::IDLE, parallel_2.status());
+    ASSERT_EQ(NodeStatus::SUCCESS, state);
 
-    root->halt();
+    root.halt();
 }
 
 int main(int argc, char** argv)

--- a/gtest/src/action_test_node.cpp
+++ b/gtest/src/action_test_node.cpp
@@ -28,12 +28,12 @@ BT::ActionTestNode::~ActionTestNode()
 BT::NodeStatus BT::ActionTestNode::tick()
 {
     int i = 0;
-    while (status() != BT::HALTED && i++ < time_)
+    while (status() != BT::IDLE && i++ < time_)
     {
         DEBUG_STDOUT(" Action " << name() << "running! Thread id:" << std::this_thread::get_id());
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    if (status() != BT::HALTED)
+    if (status() != BT::IDLE)
     {
         if (boolean_value_)
         {
@@ -48,13 +48,13 @@ BT::NodeStatus BT::ActionTestNode::tick()
     }
     else
     {
-        return BT::HALTED;
+        return BT::IDLE;
     }
 }
 
 void BT::ActionTestNode::halt()
 {
-    setStatus(BT::HALTED);
+    setStatus(BT::IDLE);
     DEBUG_STDOUT("HALTED state set!");
 }
 

--- a/include/behavior_tree_core/action_node.h
+++ b/include/behavior_tree_core/action_node.h
@@ -94,13 +94,13 @@ class ActionNode : public ActionNodeBase
     // This method MUST to be overriden by the user.
     virtual NodeStatus tick() override
     {
-        return BT::HALTED;
+        return BT::IDLE;
     }
 
     // This method MUST to be overriden by the user.
     virtual void halt() override
     {
-        setStatus(BT::HALTED);
+        setStatus(BT::IDLE);
     }
 
     void stopAndJoinThread();

--- a/include/behavior_tree_core/tree_node.h
+++ b/include/behavior_tree_core/tree_node.h
@@ -59,7 +59,6 @@ enum NodeStatus
     SUCCESS,
     FAILURE,
     IDLE,
-    HALTED,
     EXIT
 };
 

--- a/src/action_node.cpp
+++ b/src/action_node.cpp
@@ -28,7 +28,7 @@ BT::NodeStatus BT::SimpleActionNode::tick()
 {
     NodeStatus prev_status = status();
 
-    if (prev_status == BT::IDLE || prev_status == BT::HALTED)
+    if (prev_status == BT::IDLE || prev_status == BT::IDLE)
     {
         setStatus(BT::RUNNING);
         prev_status = BT::RUNNING;
@@ -68,10 +68,8 @@ void BT::ActionNode::waitForTick()
         // check this again because the tick_engine_ could be
         // notified from the method stopAndJoinThread
         if (loop_.load())
-        {
-            setStatus(BT::RUNNING);
-            BT::NodeStatus status = tick();
-            setStatus(status);
+        {       
+            setStatus( tick() );
         }
     }
 }
@@ -79,13 +77,13 @@ void BT::ActionNode::waitForTick()
 BT::NodeStatus BT::ActionNode::executeTick()
 {
     NodeStatus stat = status();
+    tick_engine_.notify();
 
-    if (stat == BT::IDLE || stat == BT::HALTED)
+    if (stat == BT::IDLE)
     {
-        DEBUG_STDOUT("NEEDS TO TICK " << name());
-        tick_engine_.notify();
-        stat = waitValidStatus();
+        setStatus(BT::RUNNING);
     }
+    stat = waitValidStatus();
     return stat;
 }
 

--- a/src/control_node.cpp
+++ b/src/control_node.cpp
@@ -43,7 +43,7 @@ void BT::ControlNode::halt()
 {
     DEBUG_STDOUT("HALTING: " << name());
     haltChildren(0);
-    setStatus(BT::HALTED);
+    setStatus(BT::IDLE);
 }
 
 const std::vector<BT::TreeNode*>& BT::ControlNode::children() const

--- a/src/decorator_node.cpp
+++ b/src/decorator_node.cpp
@@ -33,7 +33,7 @@ void BT::DecoratorNode::halt()
 {
     DEBUG_STDOUT("HALTING: " << name());
     haltChild();
-    setStatus(BT::HALTED);
+    setStatus(BT::IDLE);
 }
 
 const BT::TreeNode* BT::DecoratorNode::child() const

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -39,21 +39,21 @@ BT::ReturnStatus MyAction::Tick()
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     if (is_halted())
     {
-        return BT::HALTED;
+        return BT::IDLE;
     }
 
     std::cout << "The Action is doing some others operations" << std::endl;
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     if (is_halted())
     {
-        return BT::HALTED;
+        return BT::IDLE;
     }
 
     std::cout << "The Action is doing more operations" << std::endl;
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     if (is_halted())
     {
-        return BT::HALTED;
+        return BT::IDLE;
     }
 
     std::cout << "The Action has succeeded" << std::endl;

--- a/src/fallback_node.cpp
+++ b/src/fallback_node.cpp
@@ -27,10 +27,9 @@ BT::NodeStatus BT::FallbackNode::tick()
 
         for (unsigned i = 0; i < N_of_children; i++)
         {
-            auto& child_node = children_nodes_[i];
+            TreeNode* child_node = children_nodes_[i];
 
             const NodeStatus child_status = child_node->executeTick();
-            child_node->setStatus(child_status);
 
             // Ponderate on which status to send to the parent
             if (child_status != BT::FAILURE)
@@ -42,7 +41,6 @@ BT::NodeStatus BT::FallbackNode::tick()
                 // If the  child status is not failure, halt the next children and return the status to your parent.
                 DEBUG_STDOUT(name() << " is HALTING children from " << (i + 1));
                 haltChildren(i + 1);
-                setStatus(child_status);
                 return child_status;
             }
             else
@@ -53,7 +51,6 @@ BT::NodeStatus BT::FallbackNode::tick()
                 {
                     // If the  child status is failure, and it is the last child to be ticked,
                     // then the sequence has failed.
-                    setStatus(BT::FAILURE);
                     return BT::FAILURE;
                 }
             }

--- a/src/fallback_node_with_memory.cpp
+++ b/src/fallback_node_with_memory.cpp
@@ -32,19 +32,16 @@ BT::NodeStatus BT::FallbackNodeWithMemory::tick()
 
         const NodeStatus child_status = current_child_node->executeTick();
 
-        if (child_status == BT::SUCCESS || child_status == BT::FAILURE)
-        {
-            // the child goes in idle if it has returned success or failure.
-            current_child_node->setStatus(BT::IDLE);
-        }
-
         if (child_status != BT::FAILURE)
         {
             // If the  child status is not success, return the status
             DEBUG_STDOUT("the status of: " << name() << " becomes " << child_status);
-            if (child_status == BT::SUCCESS &&
-                (reset_policy_ == BT::ON_SUCCESS || reset_policy_ == BT::ON_SUCCESS_OR_FAILURE))
+            if (child_status == BT::SUCCESS && reset_policy_ != BT::ON_FAILURE)
             {
+                for (unsigned t=0; t<=current_child_idx_; t++)
+                {
+                    children_nodes_[t]->setStatus(BT::IDLE);
+                }
                 current_child_idx_ = 0;
             }
             return child_status;
@@ -58,8 +55,12 @@ BT::NodeStatus BT::FallbackNodeWithMemory::tick()
         else
         {
             // If it the last child.
-            if (child_status == BT::FAILURE)
+            if (child_status == BT::FAILURE && reset_policy_ != BT::ON_SUCCESS )
             {
+                for (unsigned t=0; t<=current_child_idx_; t++)
+                {
+                    children_nodes_[t]->setStatus(BT::IDLE);
+                }
                 // if it the last child and it has returned failure, reset the memory
                 current_child_idx_ = 0;
             }

--- a/src/fallback_node_with_memory.cpp
+++ b/src/fallback_node_with_memory.cpp
@@ -28,10 +28,9 @@ BT::NodeStatus BT::FallbackNodeWithMemory::tick()
     // Routing the ticks according to the fallback node's (with memory) logic:
     while (current_child_idx_ < N_of_children)
     {
-        auto& current_child_node = children_nodes_[current_child_idx_];
+        TreeNode* current_child_node = children_nodes_[current_child_idx_];
 
         const NodeStatus child_status = current_child_node->executeTick();
-        current_child_node->setStatus(child_status);
 
         if (child_status == BT::SUCCESS || child_status == BT::FAILURE)
         {
@@ -48,7 +47,6 @@ BT::NodeStatus BT::FallbackNodeWithMemory::tick()
             {
                 current_child_idx_ = 0;
             }
-            setStatus(child_status);
             return child_status;
         }
         else if (current_child_idx_ != N_of_children - 1)
@@ -65,7 +63,6 @@ BT::NodeStatus BT::FallbackNodeWithMemory::tick()
                 // if it the last child and it has returned failure, reset the memory
                 current_child_idx_ = 0;
             }
-            setStatus(child_status);
             return child_status;
         }
     }

--- a/src/parallel_node.cpp
+++ b/src/parallel_node.cpp
@@ -33,7 +33,6 @@ BT::NodeStatus BT::ParallelNode::tick()
         DEBUG_STDOUT(name() << "TICKING " << child_node);
 
         NodeStatus child_status = child_node->executeTick();
-        child_node->setStatus(child_status);
 
         switch (child_status)
         {
@@ -44,7 +43,6 @@ BT::NodeStatus BT::ParallelNode::tick()
                     success_childred_num_ = 0;
                     failure_childred_num_ = 0;
                     haltChildren(0);   // halts all running children. The execution is done.
-                    setStatus(child_status);
                     return child_status;
                 }
                 break;
@@ -58,7 +56,6 @@ BT::NodeStatus BT::ParallelNode::tick()
                     success_childred_num_ = 0;
                     failure_childred_num_ = 0;
                     haltChildren(0);   // halts all running children. The execution is hopeless.
-                    setStatus(child_status);
                     return child_status;
                 }
                 break;

--- a/src/sequence_node.cpp
+++ b/src/sequence_node.cpp
@@ -26,10 +26,9 @@ BT::NodeStatus BT::SequenceNode::tick()
 
     for (unsigned int i = 0; i < N_of_children; i++)
     {
-        auto& child_node = children_nodes_[i];
+        TreeNode* child_node = children_nodes_[i];
 
         const NodeStatus child_status = child_node->executeTick();
-        child_node->setStatus(child_status);
 
         // Ponderate on which status to send to the parent
         if (child_status != BT::SUCCESS)
@@ -42,7 +41,6 @@ BT::NodeStatus BT::SequenceNode::tick()
 
             DEBUG_STDOUT(name() << " is HALTING children from " << (i + 1));
             haltChildren(i + 1);
-            setStatus(child_status);
             return child_status;
         }
         else
@@ -54,7 +52,6 @@ BT::NodeStatus BT::SequenceNode::tick()
             {
                 // If the  child status is success, and it is the last child to be ticked,
                 // then the sequence has succeeded.
-                setStatus(BT::SUCCESS);
                 return BT::SUCCESS;
             }
         }

--- a/src/sequence_node.cpp
+++ b/src/sequence_node.cpp
@@ -36,7 +36,10 @@ BT::NodeStatus BT::SequenceNode::tick()
             // If the  child status is not success, halt the next children and return the status to your parent.
             if (child_status == BT::FAILURE)
             {
-                child_node->setStatus(BT::IDLE);   // the child goes in idle if it has returned failure.
+                for(unsigned t=0; t<=i; t++)
+                {
+                    children_nodes_[t]->setStatus( BT::IDLE );
+                }
             }
 
             DEBUG_STDOUT(name() << " is HALTING children from " << (i + 1));
@@ -45,13 +48,14 @@ BT::NodeStatus BT::SequenceNode::tick()
         }
         else
         {
-            // the child returned success.
-            child_node->setStatus(BT::IDLE);
-
             if (i == N_of_children - 1)
             {
                 // If the  child status is success, and it is the last child to be ticked,
                 // then the sequence has succeeded.
+                for(auto &ch: children_nodes_)
+                {
+                    ch->setStatus( BT::IDLE );
+                }
                 return BT::SUCCESS;
             }
         }

--- a/src/sequence_node_with_memory.cpp
+++ b/src/sequence_node_with_memory.cpp
@@ -23,20 +23,19 @@ BT::NodeStatus BT::SequenceNodeWithMemory::tick()
     DEBUG_STDOUT(name() << " ticked, memory counter: " << current_child_idx_);
 
     // Vector size initialization. N_of_children_ could change at runtime if you edit the tree
-    const unsigned N_of_children_ = children_nodes_.size();
+    const unsigned N_of_children = children_nodes_.size();
 
     // Routing the ticks according to the sequence node's (with memory) logic:
-    while (current_child_idx_ < N_of_children_)
+    while (current_child_idx_ < N_of_children)
     {
         /*      Ticking an action is different from ticking a condition. An action executed some portion of code in another thread.
                 We want this thread detached so we can cancel its execution (when the action no longer receive ticks).
                 Hence we cannot just call the method Tick() from the action as doing so will block the execution of the tree.
                 For this reason if a child of this node is an action, then we send the tick using the tick engine. Otherwise we call the method Tick() and wait for the response.
         */
-        const auto& current_child_node = children_nodes_[current_child_idx_];
+        TreeNode* current_child_node = children_nodes_[current_child_idx_];
 
         const NodeStatus child_status = current_child_node->executeTick();
-        current_child_node->setStatus(child_status);
 
         if (child_status == BT::SUCCESS || child_status == BT::FAILURE)
         {
@@ -53,10 +52,9 @@ BT::NodeStatus BT::SequenceNodeWithMemory::tick()
             {
                 current_child_idx_ = 0;
             }
-            setStatus(child_status);
             return child_status;
         }
-        else if (current_child_idx_ != N_of_children_ - 1)
+        else if (current_child_idx_ != N_of_children - 1)
         {
             // If the  child status is success, continue to the next child
             // (if any, hence if(current_child_ != N_of_children_ - 1) ) in the for loop (if any).
@@ -70,7 +68,6 @@ BT::NodeStatus BT::SequenceNodeWithMemory::tick()
                 // if it the last child and it has returned SUCCESS, reset the memory
                 current_child_idx_ = 0;
             }
-            setStatus(child_status);
             return child_status;
         }
     }

--- a/src/tree_node.cpp
+++ b/src/tree_node.cpp
@@ -19,7 +19,9 @@ BT::TreeNode::TreeNode(std::string name) : name_(name), status_(BT::IDLE)
 
 BT::NodeStatus BT::TreeNode::executeTick()
 {
-    return tick();
+    const NodeStatus status = tick();
+    setStatus(status);
+    return status;
 }
 
 void BT::TreeNode::setStatus(NodeStatus new_status)

--- a/src/tree_node.cpp
+++ b/src/tree_node.cpp
@@ -65,5 +65,5 @@ const std::string& BT::TreeNode::name() const
 
 bool BT::TreeNode::isHalted() const
 {
-    return status() == BT::HALTED;
+    return status() == BT::IDLE;
 }

--- a/templates/action_node_template.cpp
+++ b/templates/action_node_template.cpp
@@ -24,7 +24,7 @@ void BT::CLASSNAME::WaitForTick()
         SetStatus(BT::RUNNING);
         // Perform action...
 
-        while (Status() != BT::HALTED)
+        while (Status() != BT::IDLE)
         {
             /*HERE THE CODE TO EXECUTE FOR THE ACTION.
 	 wHEN THE ACTION HAS FINISHED CORRECLTY, CALL set_status(BT::SUCCESS)
@@ -36,6 +36,6 @@ void BT::CLASSNAME::WaitForTick()
 void BT::CLASSNAME::Halt()
 {
     /*HERE THE CODE TO PERFORM WHEN THE ACTION IS HALTED*/
-    SetStatus(BT::HALTED);
+    SetStatus(BT::IDLE);
     DEBUG_STDOUT("HALTED state set!");
 }


### PR DESCRIPTION
Hi,

I started submitting this to trigger a discussion, even if you should first merge #21 and there might be conflicts  afterward (I will fix them in that case).

So just review this, but not merge it quite yet ;)

In commit e3ff405b3c9c5c4b56f07087eb4818c54f6b8f9b I removed the **std::unique_ptr** to make the code more "pleasant to the eye". No functional changes at all.

In 8ff609c59ba16da7ac502ef33bdf9d7c7b7c29a0 the only important thing is the change in tree_node.cpp, since it introduce a stronger guaranty that the status() and the value returned by tick() are the same. NEVER trust the user !!! ;)

The quite big change is 4a6cc7a32ae428dbc2267ff7cc80f576d55f09aa .

From the point of view of observability and traceability of the state transitions, I found a bit counterintuitive (and potentially error prone) that the **ControlNodes** set an executed child that returned FAILURE or SUCCESS to IDLE immediately.

I think it makes more sense to  reset already finished children to IDLE only when a Sequence or Fallback has done doing its for or while loop.

I changes the unit test accordingly to see in practice what this means. As you will notice, I added MANY more checks.

