### PR TITLE
Obervability of state change

### DIFF
--- a/gtest/include/action_test_node.h
+++ b/gtest/include/action_test_node.h
@@ -26,8 +26,7 @@ class ActionTestNode : public ActionNode
   private:
     int time_;
     bool boolean_value_;
-
-    ///ReturnStatus status_;
+    std::atomic_bool stop_loop_;
 };
 }
 

--- a/gtest/src/action_test_node.cpp
+++ b/gtest/src/action_test_node.cpp
@@ -18,6 +18,7 @@ BT::ActionTestNode::ActionTestNode(std::string name) : ActionNode(name)
 {
     boolean_value_ = true;
     time_ = 3;
+    stop_loop_ = false;
 }
 
 BT::ActionTestNode::~ActionTestNode()
@@ -27,13 +28,15 @@ BT::ActionTestNode::~ActionTestNode()
 
 BT::NodeStatus BT::ActionTestNode::tick()
 {
+    stop_loop_ = false;
     int i = 0;
-    while (status() != BT::IDLE && i++ < time_)
+    while ( !stop_loop_ && i++ < time_)
     {
         DEBUG_STDOUT(" Action " << name() << "running! Thread id:" << std::this_thread::get_id());
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    if (status() != BT::IDLE)
+
+    if ( !stop_loop_ )
     {
         if (boolean_value_)
         {
@@ -54,6 +57,7 @@ BT::NodeStatus BT::ActionTestNode::tick()
 
 void BT::ActionTestNode::halt()
 {
+    stop_loop_ = true;
     setStatus(BT::IDLE);
     DEBUG_STDOUT("HALTED state set!");
 }

--- a/include/behavior_tree_core/signal.h
+++ b/include/behavior_tree_core/signal.h
@@ -1,0 +1,51 @@
+#ifndef SIMPLE_SIGNAL_H
+#define SIMPLE_SIGNAL_H
+
+#include <memory>
+#include <functional>
+#include <vector>
+
+namespace BT{
+
+/**
+ * Super simple Signal/Slop implementation, AKA "Observable pattern".
+ * The subscriber is active until it goes out of scope or Subscriber::reset() is called.
+ */
+template <typename... CallableArgs>
+class Signal{
+public:
+
+    using CallableFunction = std::function<void(CallableArgs...)>;
+    using Subscriber = std::shared_ptr<CallableFunction>;
+
+    void notify(CallableArgs... args)
+    {
+        for (size_t i=0; i< subscribers_.size(); )
+        {
+            if( auto sub = subscribers_[i].lock() )
+            {
+                (*sub)(args...);
+                i++;
+            }
+            else{
+                subscribers_.erase( subscribers_.begin()+i );
+            }
+        }
+    }
+
+    Subscriber subscribe(CallableFunction func)
+    {
+        Subscriber sub = std::make_shared<CallableFunction>(std::move(func));
+        subscribers_.emplace_back(sub);
+        return sub;
+    }
+
+private:
+
+    std::vector<std::weak_ptr<CallableFunction>> subscribers_;
+
+};
+
+}
+
+#endif // SIMPLE_SIGNAL_H


### PR DESCRIPTION
Hi,

this is a small PR that can be merged before #21, if you still need more time to review that.

- It adds a way to subscribe a callback to any state change in a TreeNode. great for logging and debugging.

- I added one more unit test where you can see how it works.

- A minor change in ActionNode, that doesn't really affect much the overall behavior.

Cheers